### PR TITLE
Add shared configs token

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,8 @@ author: 'GitHub'
 inputs: 
   repo-token:
     description: 'The GITHUB_TOKEN secret'
+  shared-configurations-token:
+    description: 'The Github token used to access shared configs'
   configuration-path:
     description: 'The path for the label configurations'
     default: '.github/labeler.yml'

--- a/dist/index.js
+++ b/dist/index.js
@@ -14537,8 +14537,12 @@ const minimatch_1 = __webpack_require__(973);
 const uniq = (arr) => [...new Set(arr)];
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
+        core.debug(`got this far`);
+        console.log("got this far regular log");
         try {
             const token = core.getInput("repo-token", { required: true });
+            const sharedConfigsToken = core.getInput("shared-configurations-token", { required: false }) ||
+                token;
             const configPath = core.getInput("configuration-path", { required: true });
             const sharedConfigurations = JSON.parse(core.getInput("shared-configurations", {
                 required: true,
@@ -14550,10 +14554,11 @@ function run() {
                 return;
             }
             const client = new github.GitHub(token);
+            const sharedConfigsClient = new github.GitHub(sharedConfigsToken);
             const { data: pullRequest } = yield client.pulls.get({
                 owner: github.context.repo.owner,
                 repo: github.context.repo.repo,
-                pull_number: prNumber
+                pull_number: prNumber,
             });
             core.debug(`fetching changed files for pr #${prNumber}`);
             const changedFiles = yield getChangedFiles(client, prNumber);
@@ -14561,7 +14566,7 @@ function run() {
             const sharedConfigGlobs = yield Promise.all(sharedConfigurations.map((config) => {
                 const [, repoOwner, repoName, repoPath] = config.match(/([^/]+)\/([^/]+)\/?(.*)?@/);
                 const [, repoRef] = config.match("@(.*)");
-                return getLabelGlobs(client, repoPath, {
+                return getLabelGlobs(sharedConfigsClient, repoPath, {
                     repoOwner,
                     repoName,
                     repoRef,
@@ -14585,7 +14590,7 @@ function run() {
                 if (checkGlobs(changedFiles, globs)) {
                     labels.push(label);
                 }
-                else if (pullRequest.labels.find(l => l.name === label)) {
+                else if (pullRequest.labels.find((l) => l.name === label)) {
                     labelsToRemove.push(label);
                 }
             }
@@ -14597,6 +14602,7 @@ function run() {
             }
         }
         catch (error) {
+            console.log("there was an error here");
             core.error(error);
             core.setFailed(error.message);
         }
@@ -14614,10 +14620,10 @@ function getChangedFiles(client, prNumber) {
         const listFilesOptions = client.pulls.listFiles.endpoint.merge({
             owner: github.context.repo.owner,
             repo: github.context.repo.repo,
-            pull_number: prNumber
+            pull_number: prNumber,
         });
         const listFilesResponse = yield client.paginate(listFilesOptions);
-        const changedFiles = listFilesResponse.map(f => f.filename);
+        const changedFiles = listFilesResponse.map((f) => f.filename);
         core.debug("found changed files:");
         for (const file of changedFiles) {
             core.debug("  " + file);
@@ -14636,6 +14642,12 @@ function getLabelGlobs(client, configurationPath, remoteRepoDetails) {
 }
 function fetchContent(client, repoPath, { repoName = github.context.repo.repo, repoOwner = github.context.repo.owner, repoRef = github.context.sha, } = {}) {
     return __awaiter(this, void 0, void 0, function* () {
+        console.log("fetching", {
+            owner: repoOwner,
+            repo: repoName,
+            path: repoPath,
+            ref: repoRef,
+        });
         const response = yield client.repos.getContents({
             owner: repoOwner,
             repo: repoName,
@@ -14663,7 +14675,7 @@ function getLabelGlobMapFromObject(configObject) {
 function toMatchConfig(config) {
     if (typeof config === "string") {
         return {
-            any: [config]
+            any: [config],
         };
     }
     return config;
@@ -14695,7 +14707,7 @@ function isMatch(changedFile, matchers) {
 }
 // equivalent to "Array.some()" but expanded for debugging and clarity
 function checkAny(changedFiles, globs) {
-    const matchers = globs.map(g => new minimatch_1.Minimatch(g));
+    const matchers = globs.map((g) => new minimatch_1.Minimatch(g));
     core.debug(`  checking "any" patterns`);
     for (const changedFile of changedFiles) {
         if (isMatch(changedFile, matchers)) {
@@ -14708,7 +14720,7 @@ function checkAny(changedFiles, globs) {
 }
 // equivalent to "Array.every()" but expanded for debugging and clarity
 function checkAll(changedFiles, globs) {
-    const matchers = globs.map(g => new minimatch_1.Minimatch(g));
+    const matchers = globs.map((g) => new minimatch_1.Minimatch(g));
     core.debug(` checking "all" patterns`);
     for (const changedFile of changedFiles) {
         if (!isMatch(changedFile, matchers)) {
@@ -14738,17 +14750,17 @@ function addLabels(client, prNumber, labels) {
             owner: github.context.repo.owner,
             repo: github.context.repo.repo,
             issue_number: prNumber,
-            labels: labels
+            labels: labels,
         });
     });
 }
 function removeLabels(client, prNumber, labels) {
     return __awaiter(this, void 0, void 0, function* () {
-        yield Promise.all(labels.map(label => client.issues.removeLabel({
+        yield Promise.all(labels.map((label) => client.issues.removeLabel({
             owner: github.context.repo.owner,
             repo: github.context.repo.repo,
             issue_number: prNumber,
-            name: label
+            name: label,
         })));
     });
 }
@@ -29715,7 +29727,7 @@ module.exports = new Schema({
 /***/ 954:
 /***/ (function(module) {
 
-module.exports = {"_args":[["@octokit/rest@16.43.1","/Users/jonathannarwold/repos/labeler-action"]],"_from":"@octokit/rest@16.43.1","_id":"@octokit/rest@16.43.1","_inBundle":false,"_integrity":"sha512-gfFKwRT/wFxq5qlNjnW2dh+qh74XgTQ2B179UX5K1HYCluioWj8Ndbgqw2PVqa1NnVJkGHp2ovMpVn/DImlmkw==","_location":"/@octokit/rest","_phantomChildren":{"@octokit/types":"2.14.0","deprecation":"2.3.1","once":"1.4.0","os-name":"3.1.0"},"_requested":{"type":"version","registry":true,"raw":"@octokit/rest@16.43.1","name":"@octokit/rest","escapedName":"@octokit%2frest","scope":"@octokit","rawSpec":"16.43.1","saveSpec":null,"fetchSpec":"16.43.1"},"_requiredBy":["/@actions/github"],"_resolved":"https://registry.npmjs.org/@octokit/rest/-/rest-16.43.1.tgz","_spec":"16.43.1","_where":"/Users/jonathannarwold/repos/labeler-action","author":{"name":"Gregor Martynus","url":"https://github.com/gr2m"},"bugs":{"url":"https://github.com/octokit/rest.js/issues"},"bundlesize":[{"path":"./dist/octokit-rest.min.js.gz","maxSize":"33 kB"}],"contributors":[{"name":"Mike de Boer","email":"info@mikedeboer.nl"},{"name":"Fabian Jakobs","email":"fabian@c9.io"},{"name":"Joe Gallo","email":"joe@brassafrax.com"},{"name":"Gregor Martynus","url":"https://github.com/gr2m"}],"dependencies":{"@octokit/auth-token":"^2.4.0","@octokit/plugin-paginate-rest":"^1.1.1","@octokit/plugin-request-log":"^1.0.0","@octokit/plugin-rest-endpoint-methods":"2.4.0","@octokit/request":"^5.2.0","@octokit/request-error":"^1.0.2","atob-lite":"^2.0.0","before-after-hook":"^2.0.0","btoa-lite":"^1.0.0","deprecation":"^2.0.0","lodash.get":"^4.4.2","lodash.set":"^4.3.2","lodash.uniq":"^4.5.0","octokit-pagination-methods":"^1.1.0","once":"^1.4.0","universal-user-agent":"^4.0.0"},"description":"GitHub REST API client for Node.js","devDependencies":{"@gimenete/type-writer":"^0.1.3","@octokit/auth":"^1.1.1","@octokit/fixtures-server":"^5.0.6","@octokit/graphql":"^4.2.0","@types/node":"^13.1.0","bundlesize":"^0.18.0","chai":"^4.1.2","compression-webpack-plugin":"^3.1.0","cypress":"^3.0.0","glob":"^7.1.2","http-proxy-agent":"^4.0.0","lodash.camelcase":"^4.3.0","lodash.merge":"^4.6.1","lodash.upperfirst":"^4.3.1","lolex":"^5.1.2","mkdirp":"^1.0.0","mocha":"^7.0.1","mustache":"^4.0.0","nock":"^11.3.3","npm-run-all":"^4.1.2","nyc":"^15.0.0","prettier":"^1.14.2","proxy":"^1.0.0","semantic-release":"^17.0.0","sinon":"^8.0.0","sinon-chai":"^3.0.0","sort-keys":"^4.0.0","string-to-arraybuffer":"^1.0.0","string-to-jsdoc-comment":"^1.0.0","typescript":"^3.3.1","webpack":"^4.0.0","webpack-bundle-analyzer":"^3.0.0","webpack-cli":"^3.0.0"},"files":["index.js","index.d.ts","lib","plugins"],"homepage":"https://github.com/octokit/rest.js#readme","keywords":["octokit","github","rest","api-client"],"license":"MIT","name":"@octokit/rest","nyc":{"ignore":["test"]},"publishConfig":{"access":"public"},"release":{"publish":["@semantic-release/npm",{"path":"@semantic-release/github","assets":["dist/*","!dist/*.map.gz"]}]},"repository":{"type":"git","url":"git+https://github.com/octokit/rest.js.git"},"scripts":{"build":"npm-run-all build:*","build:browser":"npm-run-all build:browser:*","build:browser:development":"webpack --mode development --entry . --output-library=Octokit --output=./dist/octokit-rest.js --profile --json > dist/bundle-stats.json","build:browser:production":"webpack --mode production --entry . --plugin=compression-webpack-plugin --output-library=Octokit --output-path=./dist --output-filename=octokit-rest.min.js --devtool source-map","build:ts":"npm run -s update-endpoints:typescript","coverage":"nyc report --reporter=html && open coverage/index.html","generate-bundle-report":"webpack-bundle-analyzer dist/bundle-stats.json --mode=static --no-open --report dist/bundle-report.html","lint":"prettier --check '{lib,plugins,scripts,test}/**/*.{js,json,ts}' 'docs/*.{js,json}' 'docs/src/**/*' index.js README.md package.json","lint:fix":"prettier --write '{lib,plugins,scripts,test}/**/*.{js,json,ts}' 'docs/*.{js,json}' 'docs/src/**/*' index.js README.md package.json","postvalidate:ts":"tsc --noEmit --target es6 test/typescript-validate.ts","prebuild:browser":"mkdirp dist/","pretest":"npm run -s lint","prevalidate:ts":"npm run -s build:ts","start-fixtures-server":"octokit-fixtures-server","test":"nyc mocha test/mocha-node-setup.js \"test/*/**/*-test.js\"","test:browser":"cypress run --browser chrome","update-endpoints":"npm-run-all update-endpoints:*","update-endpoints:fetch-json":"node scripts/update-endpoints/fetch-json","update-endpoints:typescript":"node scripts/update-endpoints/typescript","validate:ts":"tsc --target es6 --noImplicitAny index.d.ts"},"types":"index.d.ts","version":"16.43.1"};
+module.exports = {"name":"@octokit/rest","version":"16.43.1","publishConfig":{"access":"public"},"description":"GitHub REST API client for Node.js","keywords":["octokit","github","rest","api-client"],"author":"Gregor Martynus (https://github.com/gr2m)","contributors":[{"name":"Mike de Boer","email":"info@mikedeboer.nl"},{"name":"Fabian Jakobs","email":"fabian@c9.io"},{"name":"Joe Gallo","email":"joe@brassafrax.com"},{"name":"Gregor Martynus","url":"https://github.com/gr2m"}],"repository":"https://github.com/octokit/rest.js","dependencies":{"@octokit/auth-token":"^2.4.0","@octokit/plugin-paginate-rest":"^1.1.1","@octokit/plugin-request-log":"^1.0.0","@octokit/plugin-rest-endpoint-methods":"2.4.0","@octokit/request":"^5.2.0","@octokit/request-error":"^1.0.2","atob-lite":"^2.0.0","before-after-hook":"^2.0.0","btoa-lite":"^1.0.0","deprecation":"^2.0.0","lodash.get":"^4.4.2","lodash.set":"^4.3.2","lodash.uniq":"^4.5.0","octokit-pagination-methods":"^1.1.0","once":"^1.4.0","universal-user-agent":"^4.0.0"},"devDependencies":{"@gimenete/type-writer":"^0.1.3","@octokit/auth":"^1.1.1","@octokit/fixtures-server":"^5.0.6","@octokit/graphql":"^4.2.0","@types/node":"^13.1.0","bundlesize":"^0.18.0","chai":"^4.1.2","compression-webpack-plugin":"^3.1.0","cypress":"^3.0.0","glob":"^7.1.2","http-proxy-agent":"^4.0.0","lodash.camelcase":"^4.3.0","lodash.merge":"^4.6.1","lodash.upperfirst":"^4.3.1","lolex":"^5.1.2","mkdirp":"^1.0.0","mocha":"^7.0.1","mustache":"^4.0.0","nock":"^11.3.3","npm-run-all":"^4.1.2","nyc":"^15.0.0","prettier":"^1.14.2","proxy":"^1.0.0","semantic-release":"^17.0.0","sinon":"^8.0.0","sinon-chai":"^3.0.0","sort-keys":"^4.0.0","string-to-arraybuffer":"^1.0.0","string-to-jsdoc-comment":"^1.0.0","typescript":"^3.3.1","webpack":"^4.0.0","webpack-bundle-analyzer":"^3.0.0","webpack-cli":"^3.0.0"},"types":"index.d.ts","scripts":{"coverage":"nyc report --reporter=html && open coverage/index.html","lint":"prettier --check '{lib,plugins,scripts,test}/**/*.{js,json,ts}' 'docs/*.{js,json}' 'docs/src/**/*' index.js README.md package.json","lint:fix":"prettier --write '{lib,plugins,scripts,test}/**/*.{js,json,ts}' 'docs/*.{js,json}' 'docs/src/**/*' index.js README.md package.json","pretest":"npm run -s lint","test":"nyc mocha test/mocha-node-setup.js \"test/*/**/*-test.js\"","test:browser":"cypress run --browser chrome","build":"npm-run-all build:*","build:ts":"npm run -s update-endpoints:typescript","prebuild:browser":"mkdirp dist/","build:browser":"npm-run-all build:browser:*","build:browser:development":"webpack --mode development --entry . --output-library=Octokit --output=./dist/octokit-rest.js --profile --json > dist/bundle-stats.json","build:browser:production":"webpack --mode production --entry . --plugin=compression-webpack-plugin --output-library=Octokit --output-path=./dist --output-filename=octokit-rest.min.js --devtool source-map","generate-bundle-report":"webpack-bundle-analyzer dist/bundle-stats.json --mode=static --no-open --report dist/bundle-report.html","update-endpoints":"npm-run-all update-endpoints:*","update-endpoints:fetch-json":"node scripts/update-endpoints/fetch-json","update-endpoints:typescript":"node scripts/update-endpoints/typescript","prevalidate:ts":"npm run -s build:ts","validate:ts":"tsc --target es6 --noImplicitAny index.d.ts","postvalidate:ts":"tsc --noEmit --target es6 test/typescript-validate.ts","start-fixtures-server":"octokit-fixtures-server"},"license":"MIT","files":["index.js","index.d.ts","lib","plugins"],"nyc":{"ignore":["test"]},"release":{"publish":["@semantic-release/npm",{"path":"@semantic-release/github","assets":["dist/*","!dist/*.map.gz"]}]},"bundlesize":[{"path":"./dist/octokit-rest.min.js.gz","maxSize":"33 kB"}]};
 
 /***/ }),
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -14537,8 +14537,6 @@ const minimatch_1 = __webpack_require__(973);
 const uniq = (arr) => [...new Set(arr)];
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
-        core.debug(`got this far`);
-        console.log("got this far regular log");
         try {
             const token = core.getInput("repo-token", { required: true });
             const sharedConfigsToken = core.getInput("shared-configurations-token", { required: false }) ||
@@ -14558,7 +14556,7 @@ function run() {
             const { data: pullRequest } = yield client.pulls.get({
                 owner: github.context.repo.owner,
                 repo: github.context.repo.repo,
-                pull_number: prNumber,
+                pull_number: prNumber
             });
             core.debug(`fetching changed files for pr #${prNumber}`);
             const changedFiles = yield getChangedFiles(client, prNumber);
@@ -14590,7 +14588,7 @@ function run() {
                 if (checkGlobs(changedFiles, globs)) {
                     labels.push(label);
                 }
-                else if (pullRequest.labels.find((l) => l.name === label)) {
+                else if (pullRequest.labels.find(l => l.name === label)) {
                     labelsToRemove.push(label);
                 }
             }
@@ -14602,7 +14600,6 @@ function run() {
             }
         }
         catch (error) {
-            console.log("there was an error here");
             core.error(error);
             core.setFailed(error.message);
         }
@@ -14620,10 +14617,10 @@ function getChangedFiles(client, prNumber) {
         const listFilesOptions = client.pulls.listFiles.endpoint.merge({
             owner: github.context.repo.owner,
             repo: github.context.repo.repo,
-            pull_number: prNumber,
+            pull_number: prNumber
         });
         const listFilesResponse = yield client.paginate(listFilesOptions);
-        const changedFiles = listFilesResponse.map((f) => f.filename);
+        const changedFiles = listFilesResponse.map(f => f.filename);
         core.debug("found changed files:");
         for (const file of changedFiles) {
             core.debug("  " + file);
@@ -14642,12 +14639,6 @@ function getLabelGlobs(client, configurationPath, remoteRepoDetails) {
 }
 function fetchContent(client, repoPath, { repoName = github.context.repo.repo, repoOwner = github.context.repo.owner, repoRef = github.context.sha, } = {}) {
     return __awaiter(this, void 0, void 0, function* () {
-        console.log("fetching", {
-            owner: repoOwner,
-            repo: repoName,
-            path: repoPath,
-            ref: repoRef,
-        });
         const response = yield client.repos.getContents({
             owner: repoOwner,
             repo: repoName,
@@ -14675,7 +14666,7 @@ function getLabelGlobMapFromObject(configObject) {
 function toMatchConfig(config) {
     if (typeof config === "string") {
         return {
-            any: [config],
+            any: [config]
         };
     }
     return config;
@@ -14707,7 +14698,7 @@ function isMatch(changedFile, matchers) {
 }
 // equivalent to "Array.some()" but expanded for debugging and clarity
 function checkAny(changedFiles, globs) {
-    const matchers = globs.map((g) => new minimatch_1.Minimatch(g));
+    const matchers = globs.map(g => new minimatch_1.Minimatch(g));
     core.debug(`  checking "any" patterns`);
     for (const changedFile of changedFiles) {
         if (isMatch(changedFile, matchers)) {
@@ -14720,7 +14711,7 @@ function checkAny(changedFiles, globs) {
 }
 // equivalent to "Array.every()" but expanded for debugging and clarity
 function checkAll(changedFiles, globs) {
-    const matchers = globs.map((g) => new minimatch_1.Minimatch(g));
+    const matchers = globs.map(g => new minimatch_1.Minimatch(g));
     core.debug(` checking "all" patterns`);
     for (const changedFile of changedFiles) {
         if (!isMatch(changedFile, matchers)) {
@@ -14750,17 +14741,17 @@ function addLabels(client, prNumber, labels) {
             owner: github.context.repo.owner,
             repo: github.context.repo.repo,
             issue_number: prNumber,
-            labels: labels,
+            labels: labels
         });
     });
 }
 function removeLabels(client, prNumber, labels) {
     return __awaiter(this, void 0, void 0, function* () {
-        yield Promise.all(labels.map((label) => client.issues.removeLabel({
+        yield Promise.all(labels.map(label => client.issues.removeLabel({
             owner: github.context.repo.owner,
             repo: github.context.repo.repo,
             issue_number: prNumber,
-            name: label,
+            name: label
         })));
     });
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,7 +44,7 @@ async function run() {
     const { data: pullRequest } = await client.pulls.get({
       owner: github.context.repo.owner,
       repo: github.context.repo.repo,
-      pull_number: prNumber,
+      pull_number: prNumber
     });
 
     core.debug(`fetching changed files for pr #${prNumber}`);
@@ -92,7 +92,7 @@ async function run() {
       core.debug(`processing ${label}`);
       if (checkGlobs(changedFiles, globs)) {
         labels.push(label);
-      } else if (pullRequest.labels.find((l) => l.name === label)) {
+      } else if (pullRequest.labels.find(l => l.name === label)) {
         labelsToRemove.push(label);
       }
     }
@@ -126,11 +126,11 @@ async function getChangedFiles(
   const listFilesOptions = client.pulls.listFiles.endpoint.merge({
     owner: github.context.repo.owner,
     repo: github.context.repo.repo,
-    pull_number: prNumber,
+    pull_number: prNumber
   });
 
   const listFilesResponse = await client.paginate(listFilesOptions);
-  const changedFiles = listFilesResponse.map((f) => f.filename);
+  const changedFiles = listFilesResponse.map(f => f.filename);
 
   core.debug("found changed files:");
   for (const file of changedFiles) {
@@ -199,7 +199,7 @@ function getLabelGlobMapFromObject(
 function toMatchConfig(config: StringOrMatchConfig): MatchConfig {
   if (typeof config === "string") {
     return {
-      any: [config],
+      any: [config]
     };
   }
 
@@ -240,7 +240,7 @@ function isMatch(changedFile: string, matchers: IMinimatch[]): boolean {
 
 // equivalent to "Array.some()" but expanded for debugging and clarity
 function checkAny(changedFiles: string[], globs: string[]): boolean {
-  const matchers = globs.map((g) => new Minimatch(g));
+  const matchers = globs.map(g => new Minimatch(g));
   core.debug(`  checking "any" patterns`);
   for (const changedFile of changedFiles) {
     if (isMatch(changedFile, matchers)) {
@@ -255,7 +255,7 @@ function checkAny(changedFiles: string[], globs: string[]): boolean {
 
 // equivalent to "Array.every()" but expanded for debugging and clarity
 function checkAll(changedFiles: string[], globs: string[]): boolean {
-  const matchers = globs.map((g) => new Minimatch(g));
+  const matchers = globs.map(g => new Minimatch(g));
   core.debug(` checking "all" patterns`);
   for (const changedFile of changedFiles) {
     if (!isMatch(changedFile, matchers)) {
@@ -293,7 +293,7 @@ async function addLabels(
     owner: github.context.repo.owner,
     repo: github.context.repo.repo,
     issue_number: prNumber,
-    labels: labels,
+    labels: labels
   });
 }
 
@@ -303,12 +303,12 @@ async function removeLabels(
   labels: string[]
 ) {
   await Promise.all(
-    labels.map((label) =>
+    labels.map(label =>
       client.issues.removeLabel({
         owner: github.context.repo.owner,
         repo: github.context.repo.repo,
         issue_number: prNumber,
-        name: label,
+        name: label
       })
     )
   );

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,7 @@ const uniq = (arr) => [...new Set(arr)];
 async function run() {
   try {
     const token = core.getInput("repo-token", { required: true });
+    const sharedConfigsToken = core.getInput("shared-configurations-token", { required: false }) || token;
     const configPath = core.getInput("configuration-path", { required: true });
     const sharedConfigurations = JSON.parse(
       core.getInput("shared-configurations", {
@@ -36,6 +37,7 @@ async function run() {
     }
 
     const client = new github.GitHub(token);
+    const sharedConfigsClient = new github.GitHub(sharedConfigsToken);
 
     const { data: pullRequest } = await client.pulls.get({
       owner: github.context.repo.owner,
@@ -58,7 +60,7 @@ async function run() {
           /([^/]+)\/([^/]+)\/?(.*)?@/
         );
         const [, repoRef] = config.match("@(.*)");
-        return getLabelGlobs(client, repoPath, {
+        return getLabelGlobs(sharedConfigsClient, repoPath, {
           repoOwner,
           repoName,
           repoRef,

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,8 @@ type StringOrMatchConfig = string | MatchConfig;
 const uniq = (arr) => [...new Set(arr)];
 
 async function run() {
+  core.debug(`got this far`);
+  console.log('got this far regular log')
   try {
     const token = core.getInput("repo-token", { required: true });
     const sharedConfigsToken = core.getInput("shared-configurations-token", { required: false }) || token;

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,10 +20,12 @@ const uniq = (arr) => [...new Set(arr)];
 
 async function run() {
   core.debug(`got this far`);
-  console.log('got this far regular log')
+  console.log("got this far regular log");
   try {
     const token = core.getInput("repo-token", { required: true });
-    const sharedConfigsToken = core.getInput("shared-configurations-token", { required: false }) || token;
+    const sharedConfigsToken =
+      core.getInput("shared-configurations-token", { required: false }) ||
+      token;
     const configPath = core.getInput("configuration-path", { required: true });
     const sharedConfigurations = JSON.parse(
       core.getInput("shared-configurations", {
@@ -44,7 +46,7 @@ async function run() {
     const { data: pullRequest } = await client.pulls.get({
       owner: github.context.repo.owner,
       repo: github.context.repo.repo,
-      pull_number: prNumber
+      pull_number: prNumber,
     });
 
     core.debug(`fetching changed files for pr #${prNumber}`);
@@ -92,7 +94,7 @@ async function run() {
       core.debug(`processing ${label}`);
       if (checkGlobs(changedFiles, globs)) {
         labels.push(label);
-      } else if (pullRequest.labels.find(l => l.name === label)) {
+      } else if (pullRequest.labels.find((l) => l.name === label)) {
         labelsToRemove.push(label);
       }
     }
@@ -105,7 +107,7 @@ async function run() {
       await removeLabels(client, prNumber, labelsToRemove);
     }
   } catch (error) {
-    console.log('there was an error here')
+    console.log("there was an error here");
     core.error(error);
     core.setFailed(error.message);
   }
@@ -127,11 +129,11 @@ async function getChangedFiles(
   const listFilesOptions = client.pulls.listFiles.endpoint.merge({
     owner: github.context.repo.owner,
     repo: github.context.repo.repo,
-    pull_number: prNumber
+    pull_number: prNumber,
   });
 
   const listFilesResponse = await client.paginate(listFilesOptions);
-  const changedFiles = listFilesResponse.map(f => f.filename);
+  const changedFiles = listFilesResponse.map((f) => f.filename);
 
   core.debug("found changed files:");
   for (const file of changedFiles) {
@@ -168,22 +170,18 @@ async function fetchContent(
     repoRef = github.context.sha,
   }: RemoteRepoDetails = {}
 ): Promise<string> {
-  console.log('fetching', {
+  console.log("fetching", {
     owner: repoOwner,
     repo: repoName,
     path: repoPath,
     ref: repoRef,
-  })
-  try {
-    const response: any = await client.repos.getContents({
-      owner: repoOwner,
-      repo: repoName,
-      path: repoPath,
-      ref: repoRef,
-    });
-  } catch (e) {
-    console.log('error fetching', e)
-  }
+  });
+  const response: any = await client.repos.getContents({
+    owner: repoOwner,
+    repo: repoName,
+    path: repoPath,
+    ref: repoRef,
+  });
 
   return Buffer.from(response.data.content, response.data.encoding).toString();
 }
@@ -210,7 +208,7 @@ function getLabelGlobMapFromObject(
 function toMatchConfig(config: StringOrMatchConfig): MatchConfig {
   if (typeof config === "string") {
     return {
-      any: [config]
+      any: [config],
     };
   }
 
@@ -251,7 +249,7 @@ function isMatch(changedFile: string, matchers: IMinimatch[]): boolean {
 
 // equivalent to "Array.some()" but expanded for debugging and clarity
 function checkAny(changedFiles: string[], globs: string[]): boolean {
-  const matchers = globs.map(g => new Minimatch(g));
+  const matchers = globs.map((g) => new Minimatch(g));
   core.debug(`  checking "any" patterns`);
   for (const changedFile of changedFiles) {
     if (isMatch(changedFile, matchers)) {
@@ -266,7 +264,7 @@ function checkAny(changedFiles: string[], globs: string[]): boolean {
 
 // equivalent to "Array.every()" but expanded for debugging and clarity
 function checkAll(changedFiles: string[], globs: string[]): boolean {
-  const matchers = globs.map(g => new Minimatch(g));
+  const matchers = globs.map((g) => new Minimatch(g));
   core.debug(` checking "all" patterns`);
   for (const changedFile of changedFiles) {
     if (!isMatch(changedFile, matchers)) {
@@ -304,7 +302,7 @@ async function addLabels(
     owner: github.context.repo.owner,
     repo: github.context.repo.repo,
     issue_number: prNumber,
-    labels: labels
+    labels: labels,
   });
 }
 
@@ -314,12 +312,12 @@ async function removeLabels(
   labels: string[]
 ) {
   await Promise.all(
-    labels.map(label =>
+    labels.map((label) =>
       client.issues.removeLabel({
         owner: github.context.repo.owner,
         repo: github.context.repo.repo,
         issue_number: prNumber,
-        name: label
+        name: label,
       })
     )
   );

--- a/src/main.ts
+++ b/src/main.ts
@@ -165,12 +165,22 @@ async function fetchContent(
     repoRef = github.context.sha,
   }: RemoteRepoDetails = {}
 ): Promise<string> {
-  const response: any = await client.repos.getContents({
+  console.log('fetching', {
     owner: repoOwner,
     repo: repoName,
     path: repoPath,
     ref: repoRef,
-  });
+  })
+  try {
+    const response: any = await client.repos.getContents({
+      owner: repoOwner,
+      repo: repoName,
+      path: repoPath,
+      ref: repoRef,
+    });
+  } catch (e) {
+    console.log('error fetching', e)
+  }
 
   return Buffer.from(response.data.content, response.data.encoding).toString();
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,8 +19,6 @@ type StringOrMatchConfig = string | MatchConfig;
 const uniq = (arr) => [...new Set(arr)];
 
 async function run() {
-  core.debug(`got this far`);
-  console.log("got this far regular log");
   try {
     const token = core.getInput("repo-token", { required: true });
     const sharedConfigsToken =
@@ -107,7 +105,6 @@ async function run() {
       await removeLabels(client, prNumber, labelsToRemove);
     }
   } catch (error) {
-    console.log("there was an error here");
     core.error(error);
     core.setFailed(error.message);
   }
@@ -170,12 +167,6 @@ async function fetchContent(
     repoRef = github.context.sha,
   }: RemoteRepoDetails = {}
 ): Promise<string> {
-  console.log("fetching", {
-    owner: repoOwner,
-    repo: repoName,
-    path: repoPath,
-    ref: repoRef,
-  });
   const response: any = await client.repos.getContents({
     owner: repoOwner,
     repo: repoName,

--- a/src/main.ts
+++ b/src/main.ts
@@ -103,6 +103,7 @@ async function run() {
       await removeLabels(client, prNumber, labelsToRemove);
     }
   } catch (error) {
+    console.log('there was an error here')
     core.error(error);
     core.setFailed(error.message);
   }


### PR DESCRIPTION
## Context

We use `GITHUB_TOKEN` to authorize the labeler to do whatever it needs to do on a PR (add labels for example). However, we also need a low-level access to other repos in order to be able to pull shared labels from a private repo. This PR adds a secondary token to the labeler to support optional alternate credentials for this purpose.